### PR TITLE
Fix macro not working

### DIFF
--- a/clean_nozzle.cfg
+++ b/clean_nozzle.cfg
@@ -25,7 +25,7 @@
 # ooze dwell variable makes allowance for this. Update as necessary. If you decided to not enable purge, you can ignore this section.
 variable_purge_len:            10          ; Amount of filament, in mm, to purge.
 variable_purge_spd:           200          ; Speed, in mm/min, of the purge.
-variable_purge_temp_min:      190          ; Minimum nozzle temperature to permit a purge. Otherwise, purge will not occur.
+variable_purge_temp_min:      150          ; Minimum nozzle temperature to permit a purge. Otherwise, purge will not occur.
 variable_purge_ret:             2          ; Retract length, in mm, after purging to prevent slight oozing. Adjust as necessary.
 variable_ooze_offset_z:        40          ; After purging, how far up to move Z, in mm.
 variable_ooze_spd_z:          120          ; After purging, how fast to move up Z, in mm/min.
@@ -71,7 +71,7 @@ variable_wipe_travel:          20 # distance to travel when claening in mm
 #variable_bucket_left_width:    67
 
 ## For V2.4 350mm build, uncomment below
-#variable_bucket_left_width:    92   
+variable_bucket_left_width:    92   
 
 # These values are defaulted from bucket geometry in CAD (rear left location). Change only if you're using a custom bucket.
 variable_bucket_right_width:   40            
@@ -125,7 +125,7 @@ gcode:
     G1 X{bucket_start + (bucket_left_width / (2 - bucket_pos)) + (bucket_pos * bucket_gap) + (bucket_pos * (bucket_right_width / 2))}
   
     # Purge filament if temp above 150 °C is specified
-    {% if params.PURGE|default("0")|int > 150 %}
+    {% if purge_temp > purge_temp_min %}
       # Lower as far as we can go
       G1 Z{tube_top} F{prep_spd_z}
       # Heats up the nozzle up to target via data from slicer
@@ -136,17 +136,15 @@ gcode:
       
       ### Small retract after purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds,
       ### hence * 1000 in formula.
-      {% if printer.extruder.temperature >= purge_temp_min %}
-        M83        ; relative mode
-        G1 E{purge_len} F{purge_spd}
-        G1 E-{purge_ret} F{purge_spd * 5}
-        M106 S127  ; use part cooling to harden the material
-        G92 E0     ; reset extruder
-      {% endif %}
+      M83        ; relative mode
+      G1 E{purge_len} F{purge_spd}
+      G1 E-{purge_ret} F{purge_spd * 5}
+      M106 S127  ; use part cooling to harden the material
+      G92 E0     ; reset extruder
     {% endif %}
   
     # Wait till hotend is below given temperature if provided
-    {% if params.CLEAN|default("0")|int > 0 %}
+    {% if clean_temp > 0 %}
       # Cooling nozzle to a given temperature. This helps with cleanly breaking off extruded filament
       SET_DISPLAY_TEXT MSG="Hotend: {clean_temp}c"  ; Displays info
       M104 S{clean_temp}                            ; Heats the nozzle to 150c without waiting

--- a/clean_nozzle.cfg
+++ b/clean_nozzle.cfg
@@ -23,22 +23,23 @@
 # These parameters define your filament purging. The retract variable is used to retract right after purging to prevent unnecessary
 # oozing. Some filament are particularly oozy and may continue to ooze out of the nozzle for a second or two after retracting. The
 # ooze dwell variable makes allowance for this. Update as necessary. If you decided to not enable purge, you can ignore this section.
-variable_purge_len:            10	         ; Amount of filament, in mm, to purge.
-variable_purge_spd:           200	         ; Speed, in mm/min, of the purge.
+variable_purge_len:            10          ; Amount of filament, in mm, to purge.
+variable_purge_spd:           200          ; Speed, in mm/min, of the purge.
+variable_purge_temp_min:      190          ; Minimum nozzle temperature to permit a purge. Otherwise, purge will not occur.
 variable_purge_ret:             2          ; Retract length, in mm, after purging to prevent slight oozing. Adjust as necessary.
 variable_ooze_offset_z:        40          ; After purging, how far up to move Z, in mm.
 variable_ooze_spd_z:          120          ; After purging, how fast to move up Z, in mm/min.
 
 # Adjust this so that your nozzle hits the tube. The nozzle should hit the upper 1/4th to 1/2nd part of the tube.
-variable_tube_top:            4.5          ; Z position in mm
+variable_tube_top:              4.5        ; Z position in mm
 
 # These parameters define your cleaning, travel speeds, safe z clearance and how many times you want to wipe. Update as necessary. Wipe 
 # direction is randomized based off whether the left or right bucket is randomly selected in the purge & scrubbing routine.
-variable_clearance_z:           5	         ; When traveling, but not cleaning, the clearance along the z-axis between nozzle and tube.
-variable_wipe_qty:              2	         ; Number of complete (A complete wipe: left, right, left OR right, left, right) wipes.
-variable_prep_spd_xy:        6000	         ; Travel (not cleaning) speed along x and y-axis in mm/min.
-variable_prep_spd_z:         1500	         ; Travel (not cleaning) speed along z axis in mm/min.
-variable_wipe_spd_xy:        5000	         ; Nozzle wipe speed in mm/min.
+variable_clearance_z:           5          ; When traveling, but not cleaning, the clearance along the z-axis between nozzle and tube.
+variable_wipe_qty:              2          ; Number of complete (A complete wipe: left, right, left OR right, left, right) wipes.
+variable_prep_spd_xy:        6000          ; Travel (not cleaning) speed along x and y-axis in mm/min.
+variable_prep_spd_z:         1500          ; Travel (not cleaning) speed along z axis in mm/min.
+variable_wipe_spd_xy:        5000          ; Nozzle wipe speed in mm/min.
 
 # Tube position
 variable_tube_x:              110 # X position of tube, Y is assumed to be 0
@@ -70,11 +71,26 @@ variable_wipe_travel:          20 # distance to travel when claening in mm
 #variable_bucket_left_width:    67
 
 ## For V2.4 350mm build, uncomment below
-variable_bucket_left_width:    92   
+#variable_bucket_left_width:    92   
 
 # These values are defaulted from bucket geometry in CAD (rear left location). Change only if you're using a custom bucket.
 variable_bucket_right_width:   40            
-variable_bucket_gap:           22	
+variable_bucket_gap:           22
+
+# For V1.8, you may need to measure where your bucket start is and input into bucket_start. Otherwise, a value of 0 is for a default
+# installation of purge bucket at rear left.
+variable_bucket_start: 0
+
+###############################################################################################################################################
+###############################################################################################################################################
+
+### From here on, unless you know what you're doing, it's recommended not to change anything
+
+###############################################################################################################################################
+###############################################################################################################################################
+
+# Placeholder. The variable will later be set to contain, at random, a number representing the left or right bucket.
+variable_bucket_pos:            1
 
 gcode:
   
@@ -94,13 +110,13 @@ gcode:
     # Set to absolute positioning.
     G90
   
-    SET_DISPLAY_TEXT MSG="Cleaning nozzle"          # Displays info
+    SET_DISPLAY_TEXT MSG="Cleaning nozzle"          ; Displays info
   
     # Grab max position of Y-axis from config to use in setting a fixed y position.
     {% set Ry = printer.configfile.config["stepper_y"]["position_max"]|float %}
   
     # Randomly select left or right bin for purge. 0 = left, 1 = right
-    SET_GCODE_VARIABLE MACRO=clean_nozzle_2 VARIABLE=bucket_pos VALUE={(range(2) | random)}
+    SET_GCODE_VARIABLE MACRO=clean_nozzle VARIABLE=bucket_pos VALUE={(range(2) | random)}
     
     # Raise Z for travel.
     G1 Z{tube_top + clearance_z} F{prep_spd_z}
@@ -113,27 +129,30 @@ gcode:
       # Lower as far as we can go
       G1 Z{tube_top} F{prep_spd_z}
       # Heats up the nozzle up to target via data from slicer
-      SET_DISPLAY_TEXT MSG="Hotend: {purge_temp}c"  # Displays info
-      STATUS_HEATING                                # Sets SB-leds to heating-mode
-      M107                                          # Turns off partcooling fan
-      M109 S{purge_temp}                            # Heats the nozzle to printing temp
+      SET_DISPLAY_TEXT MSG="Hotend: {purge_temp}c"  ; Displays info
+      STATUS_HEATING                                ; Sets SB-leds to heating-mode
+      M107                                          ; Turns off partcooling fan
+      M109 S{purge_temp}                            ; Heats the nozzle to printing temp
       
-      # Small retract after purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds, hence * 1000 in formula.
-      M83                                           # relative mode
-      G1 E{purge_len} F{purge_spd}
-      G1 E-{purge_ret} F{purge_spd * 5}
-      M106 S127                                     # use part cooling to harden the material
-      G92 E0                                        # reset extruder
+      ### Small retract after purging to minimize any persistent oozing at 5x purge_spd. G4 dwell is in milliseconds,
+      ### hence * 1000 in formula.
+      {% if printer.extruder.temperature >= purge_temp_min %}
+        M83        ; relative mode
+        G1 E{purge_len} F{purge_spd}
+        G1 E-{purge_ret} F{purge_spd * 5}
+        M106 S127  ; use part cooling to harden the material
+        G92 E0     ; reset extruder
+      {% endif %}
     {% endif %}
   
     # Wait till hotend is below given temperature if provided
     {% if params.CLEAN|default("0")|int > 0 %}
       # Cooling nozzle to a given temperature. This helps with cleanly breaking off extruded filament
-      SET_DISPLAY_TEXT MSG="Hotend: {clean_temp}c"  # Displays info
-      M104 S{clean_temp}                            # Heats the nozzle to 150c without waiting
-      G1 Z{tube_top + ooze_offset_z} F{ooze_spd_z}  # Slowly moving up to ensure ooze is straight and can be broken off
-      M109 S{clean_temp}                            # Actually waiting for temperature to reach
-      M107                                          # stop part cooling fan
+      SET_DISPLAY_TEXT MSG="Hotend: {clean_temp}c"  ; Displays info
+      M104 S{clean_temp}                            ; Heats the nozzle to 150c without waiting
+      G1 Z{tube_top + ooze_offset_z} F{ooze_spd_z}  ; Slowly moving up to ensure ooze is straight and can be broken off
+      M109 S{clean_temp}                            ; Actually waiting for temperature to reach
+      M107                                          ; stop part cooling fan
     {% endif %}
   
     # Position for wipe. Either left or right of tube based off bucket_pos to avoid unnecessary travel.


### PR DESCRIPTION
* Adds missing variables
* Clean old macro name (clean_nozzle_2 -> clean_nozzle)
* Adds support to `purge_temp_min`